### PR TITLE
Remove @autobind for React Native 0.16

### DIFF
--- a/InfiniteScrollView.js
+++ b/InfiniteScrollView.js
@@ -8,7 +8,6 @@ let {
   View,
 } = React;
 
-let autobind = require('autobind-decorator');
 let cloneReferencedElement = require('react-native-clone-referenced-element');
 
 let DefaultLoadingIndicator = require('./DefaultLoadingIndicator');
@@ -39,6 +38,8 @@ class InfiniteScrollView extends React.Component {
     this.state = {
       isDisplayingError: false,
     };
+
+    this._onLoadMoreAsync = this._onLoadMoreAsync.bind(this);
   }
 
   getScrollResponder(): ReactComponent {
@@ -95,7 +96,6 @@ class InfiniteScrollView extends React.Component {
     }
   }
 
-  @autobind
   async _onLoadMoreAsync() {
     if (this.state.isLoading && __DEV__) {
       throw new Error('_onLoadMoreAsync called while isLoading is true');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/exponentjs/react-native-infinite-scroll-view#readme",
   "dependencies": {
-    "autobind-decorator": "^1.3.2",
     "react-native-clone-referenced-element": "^1.0.0",
     "react-native-scrollable-mixin": "^1.0.0"
   }


### PR DESCRIPTION
As babel6 in React Native 0.16 does not officially support decorator, here to remove @autobind decorator.
Code changes is simply reference from https://github.com/exponentjs/ex-navigator/commit/757b7f93236652d5f2295dcc6b8183ef0f3d5cc3
