### PR TITLE
Fixed warning regarding ProgressBarAndroid. Using ActivityIndicator instead

### DIFF
--- a/DefaultLoadingIndicator.js
+++ b/DefaultLoadingIndicator.js
@@ -2,9 +2,7 @@
 
 import React from 'react';
 import {
-  ActivityIndicatorIOS,
-  Platform,
-  ProgressBarAndroid,
+  ActivityIndicator,
   StyleSheet,
   View,
 } from 'react-native';
@@ -13,11 +11,7 @@ export default class DefaultLoadingIndicator extends React.Component {
   render() {
     return (
       <View style={styles.container}>
-        {
-          Platform.OS === 'ios' ?
-            <ActivityIndicatorIOS /> :
-            <ProgressBarAndroid styleAttr="Small" />
-        }
+        <ActivityIndicator />
       </View>
     );
   }


### PR DESCRIPTION
ProgressBarAndroid is deprecated. Using it gives warning. Instead using ActivityIndicator, which works Android as well.
