### PR TITLE
Replace ActivityIndicatorIOS with ActivityIndicator as warned by React 0.29

### DIFF
--- a/DefaultLoadingIndicator.js
+++ b/DefaultLoadingIndicator.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import {
-  ActivityIndicatorIOS,
+  ActivityIndicator,
   Platform,
   ProgressBarAndroid,
   StyleSheet,
@@ -15,7 +15,7 @@ export default class DefaultLoadingIndicator extends React.Component {
       <View style={styles.container}>
         {
           Platform.OS === 'ios' ?
-            <ActivityIndicatorIOS /> :
+            <ActivityIndicator /> :
             <ProgressBarAndroid styleAttr="Small" />
         }
       </View>


### PR DESCRIPTION
## Purpose

This change will remove the warning thrown by React 0.29. 

Warning: "ActivityIndicatorIOS is deprecated. Use ActivityIndicator instead."
