### PR TITLE
Enable canLoadMore to be a boolean or a callback

### DIFF
--- a/InfiniteScrollView.js
+++ b/InfiniteScrollView.js
@@ -21,6 +21,10 @@ export default class InfiniteScrollView extends React.Component {
     onLoadError: PropTypes.func,
     renderLoadingIndicator: PropTypes.func.isRequired,
     renderLoadingErrorIndicator: PropTypes.func.isRequired,
+    canLoadMore: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.boolean
+    ]).isRequired
   };
 
   static defaultProps = {
@@ -95,8 +99,9 @@ export default class InfiniteScrollView extends React.Component {
   }
 
   _shouldLoadMore(event) {
-    
-    var canLoadMore = (typeof this.props.canLoadMore == 'function') ? this.props.canLoadMore() : this.props.canLoadMore;
+    let canLoadMore = (typeof this.props.canLoadMore === 'function') ? 
+      this.props.canLoadMore() :
+      this.props.canLoadMore;
     
     return !this.state.isLoading &&
       canLoadMore &&

--- a/InfiniteScrollView.js
+++ b/InfiniteScrollView.js
@@ -17,7 +17,6 @@ export default class InfiniteScrollView extends React.Component {
   static propTypes = {
     ...ScrollView.propTypes,
     distanceToLoadMore: PropTypes.number.isRequired,
-    canLoadMore: PropTypes.bool.isRequired,
     onLoadMoreAsync: PropTypes.func.isRequired,
     onLoadError: PropTypes.func,
     renderLoadingIndicator: PropTypes.func.isRequired,
@@ -96,8 +95,11 @@ export default class InfiniteScrollView extends React.Component {
   }
 
   _shouldLoadMore(event) {
+    
+    var canLoadMore = (typeof this.props.canLoadMore == 'function') ? this.props.canLoadMore() : this.props.canLoadMore;
+    
     return !this.state.isLoading &&
-      this.props.canLoadMore &&
+      canLoadMore &&
       !this.state.isDisplayingError &&
       this._distanceFromEnd(event) < this.props.distanceToLoadMore;
   }


### PR DESCRIPTION
For an app I am building it's easier to evaluate canLoadMore dynamically so that I can factor in time when figuring out whether or not to load the next page.

I've expanded the code here so that if props.canLoadMore is a function, it will call the function and use its result.  It's backward compatible with the previous code, so props.canLoadMore can still be a boolean.
