### PR TITLE
Fix canLoadMore prop type

### DIFF
--- a/InfiniteScrollView.js
+++ b/InfiniteScrollView.js
@@ -19,7 +19,7 @@ export default class InfiniteScrollView extends React.Component {
     distanceToLoadMore: PropTypes.number.isRequired,
     canLoadMore: PropTypes.oneOfType([
       PropTypes.func,
-      PropTypes.boolean,
+      PropTypes.bool,
     ]).isRequired,
     onLoadMoreAsync: PropTypes.func.isRequired,
     onLoadError: PropTypes.func,


### PR DESCRIPTION
The use of `PropTypes.boolean` instead of `PropTypes.bool` was causing a warning in React Native 0.31

![Warning](https://d3vv6lp55qjaqc.cloudfront.net/items/401l1w2u3F25342e2b2G/Screen%20Shot%202016-08-10%20at%2014.32.11.png?v=e6ab11f7)
