### PR TITLE
Allow the use of an animated ScrollView

### DIFF
--- a/InfiniteScrollView.js
+++ b/InfiniteScrollView.js
@@ -81,7 +81,13 @@ export default class InfiniteScrollView extends React.Component {
     });
 
     return cloneReferencedElement(renderScrollComponent(props), {
-      ref: component => { this._scrollComponent = component; },
+      ref: component => {
+        if (component && component._component) {
+          this._scrollComponent = component._component;
+        } else {
+          this._scrollComponent = component; 
+        }
+      },
     });
   }
 


### PR DESCRIPTION
If the renderScrollComponent props returns an <Animated.ScrollView>, use component._component as a ref to access the ScrollView component