### PR TITLE
Remove trailing comma from last rest-spread item

### DIFF
--- a/InfiniteScrollView.js
+++ b/InfiniteScrollView.js
@@ -73,7 +73,7 @@ export default class InfiniteScrollView extends React.Component {
 
     let {
       renderScrollComponent,
-      ...props,
+      ...props
     } = this.props;
     Object.assign(props, {
       onScroll: this._handleScroll,


### PR DESCRIPTION
A trailing comma is not permitted after the rest element. This might raise errors in some environments. See https://github.com/facebook/react-native/issues/10199